### PR TITLE
Update the facebook photo rule to match reality

### DIFF
--- a/addon/data/rules.json
+++ b/addon/data/rules.json
@@ -110,7 +110,7 @@
           }
         }
       },
-      "^/photo.php$": {
+      "^/photo$": {
         "actions": {
           "whitelist": [
             "fbid"


### PR DESCRIPTION
Facebook doesn't use ".php" anymore when accessing photos. Fixes: broken facebook photos links